### PR TITLE
Added cpu_freq to PosixPsutil::CPU

### DIFF
--- a/lib/posixpsutil/linux/system.rb
+++ b/lib/posixpsutil/linux/system.rb
@@ -125,6 +125,88 @@ class CPU
     end
     @logical_cpu_count
   end
+  
+  #Return the average CPU frequencies or the
+	#frequencies of all system cores
+  def self.cpu_freq(cores=false)
+    direc = '/sys/devices/system/cpu/cpufreq'
+		cpu_freqs = []
+		out  = false
+		
+		#If the normal system file exists
+		if File.directory?(direc)
+			`ls #{direc}`.split("\n").each {|line|
+				if line.match(/^policy/)
+					out = {}
+					files = `ls #{direc}/#{line.chomp}`.split("\n")
+					#puts files
+					files.each {|file|
+						if file.match('_cur_freq') or file.match('_max_freq') or file.match('_min_freq')
+							out["#{file}"] = (`cat #{direc}/#{line}/#{file}`.to_i / 1000).to_s.chomp + " MHz"
+						end
+					}
+					cpu_freqs << out
+				end
+			}
+			
+			#If the user has requested each core, return the
+			#hash as-is
+			if cores
+				out = cpu_freqs
+				
+			#Otherwise, calculate averages
+			else
+				avg_min = 0
+				avg_max = 0
+				avg_cur = 0
+
+				cpu_freqs.each do |freqs|
+					if freqs['scaling_cur_freq']
+						avg_min += freqs['scaling_min_freq'].to_f
+						avg_max += freqs['scaling_max_freq'].to_f
+						avg_cur += freqs['scaling_cur_freq'].to_f
+					else
+						avg_min += freqs['cpuinfo_min_freq'].to_f
+						avg_max += freqs['cpuinfo_max_freq'].to_f
+						avg_cur += freqs['cpuinfo_cur_freq'].to_f
+					end
+				end
+				
+				out = {:cpu_min => (avg_min / cpu_freqs.length).to_f.round(2).to_s + " MHz",
+					:cpu_max => (avg_max / cpu_freqs.length).to_f.round(2).to_s + " MHz",
+					:cpu_cur => (avg_cur / cpu_freqs.length).to_f.round(2).to_s + " MHz"}
+			end
+		#If the normal file does not exist, fallback to CPU proc file
+		else
+			cpu_freqs = []
+			proc_cpu = File.open('/proc/cpuinfo', 'r').readlines.join
+			core_list = proc_cpu.split(/^[\w]*$/)
+
+			core_list.delete_if {|core| core.chomp == ''}
+
+			core_list.each do |core|
+				val = core[/^cpu MHz.+$/].gsub(/[^\d\.]/, '').to_f.round(2)
+				cpu_freqs << val
+			end
+			
+			#If the user wishes to see cores separately
+			if cores
+				out = cpu_freqs
+			#Otherwise, if they want general averages
+			else
+				avg_cur = 0
+				cpu_freqs.each do |freq|
+					avg_cur += freq.to_f.round(2)
+				end
+				
+				out = {:cpu_min => ("NIL"),
+					:cpu_max => ("NIL"),
+					:cpu_cur => (avg_cur / cpu_freqs.length).to_f.round(2).to_s + " MHz"}
+			end
+		end
+		
+		out
+  end
 
   # The  amount  of  time,  measured in units of +USER_HZ+
   # (1/100ths of a second on most architectures, 

--- a/lib/posixpsutil/linux/system.rb
+++ b/lib/posixpsutil/linux/system.rb
@@ -620,12 +620,13 @@ class System
   end
   
   #Display information about the OS
-  def self.system_info
-    {:os_short => `uname -s`.chomp,
-    :os_full => `uname -o`.chomp,
-    :kernel => `uname -r`.chomp,
-    :arch => `uname -m`.chomp,
-    :hostname => `hostname`.chomp}
+  def self.uname
+    un = `uname -mnors`.chomp.split(' ')
+    {:kernel_name => un[0],
+    :kernel_release => un[2],
+    :os_name => un[4],
+    :arch => un[3],
+    :hostname => un[1]}
   end
 
   # return system boot time expressed in seconds since epoch


### PR DESCRIPTION
This returns any of the following:
If the file '/sys/devices/system/cpu/cpufreq' is present:
-A hash of the average minimum, maximum, and current CPU frequencies, by default
-An array of hashes for each CPU core on the system showing the minimum, maximum, and current frequencies on that core, if "cores" is set to "true"

And if that file is NOT present, it will proc '/proc/cpuinfo' and return:
-A hash with a "NIL" maximum and minimum frequency, but an average of all the cores' frequencies for the current, by default
-An array of core frequencies (as floats, rounded to 2 decimal places), if "cores" is set to "true"